### PR TITLE
feat: link nyla ui repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ui"]
+	path = ui
+	url = git@github.com:joepurdy/nyla-ui.git


### PR DESCRIPTION
This PR adds a git submodule for the Nyla UI. I need to sort out some licensing questions before open sourcing the UI so for now it's a private repository.

In the future I'll just bring it into the core repo directly once licensing is sorted.